### PR TITLE
[issue-12] Add ability to set broker properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .settings/
 target/
 README.md.bak
-
+*.versionsBackup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.
 - Deprecated KafkaTestServer constructor: `public KafkaTestServer(final String localHostname)`
   
-  This constructor was replaced with the constructor `KafkaTestServer(final Properties overrideBrokerProperties)` where overrideBrokerProperties contains the property `host.name` set to the hostname or IP address Kafka should use. 
+  This constructor was replaced with the constructor `KafkaTestServer(final Properties overrideBrokerProperties)` where overrideBrokerProperties should contain the property `host.name` set to the hostname or IP address Kafka should use. 
 
 ## 2.2.0 (4/24/2018)
 - [Issue-5](https://github.com/salesforce/kafka-junit/issues/5) Updated to support Kafka versions 1.0.x and 1.1.x.  Thanks [kasuri](https://github.com/kasuri)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.1 (5/16/2018)
+- [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
+- Added helper method getAdminClient() on KafkaTestServer. 
+
 ## 2.2.0 (4/24/2018)
 - [Issue-5](https://github.com/salesforce/kafka-junit/issues/5) Updated to support Kafka versions 1.0.x and 1.1.x.  Thanks [kasuri](https://github.com/kasuri)!
 - [Issue-4](https://github.com/salesforce/kafka-junit/issues/4) Fix server configuration to allow for transactional producers & consumers. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.2.1 (5/16/2018)
 - [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
+- Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.
 - Added helper method getAdminClient() on KafkaTestServer. 
 
 ## 2.2.0 (4/24/2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.2.1 (5/16/2018)
+## 2.3.0 (5/17/2018)
 - [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
 - Added helper method getAdminClient() on KafkaTestServer to get a configured AdminClient instance.
 - Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.2.1 (5/16/2018)
 - [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
+- Added helper method getAdminClient() on KafkaTestServer to get a configured AdminClient instance.
 - Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.
-- Added helper method getAdminClient() on KafkaTestServer. 
+- Deprecated KafkaTestServer constructor: `public KafkaTestServer(final String localHostname)`
+  
+  This constructor was replaced with the constructor `KafkaTestServer(final Properties overrideBrokerProperties)` where overrideBrokerProperties contains the property `host.name` set to the hostname or IP address Kafka should use. 
 
 ## 2.2.0 (4/24/2018)
 - [Issue-5](https://github.com/salesforce/kafka-junit/issues/5) Updated to support Kafka versions 1.0.x and 1.1.x.  Thanks [kasuri](https://github.com/kasuri)!

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <!-- Module Dependencies -->
     <dependencies>

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.1</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
 
     <!-- Module Dependencies -->
     <dependencies>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
@@ -155,7 +155,8 @@ public class KafkaTestServer implements AutoCloseable {
         final String zkConnectionString = getZookeeperServer().getConnectString();
 
         // Build properties using a baseline from overrideBrokerProperties.
-        final Properties brokerProperties = new Properties(overrideBrokerProperties);
+        final Properties brokerProperties = new Properties();
+        brokerProperties.putAll(overrideBrokerProperties);
 
         // Put required zookeeper connection properties.
         setPropertyIfNotSet(brokerProperties, "zookeeper.connect", zkConnectionString);

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.kafka.test;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import kafka.server.KafkaConfig;
@@ -77,6 +78,11 @@ public class KafkaTestServer implements AutoCloseable {
     private final String localHostname;
 
     /**
+     * Defines overridden broker properties.
+     */
+    private final Properties overrideBrokerProperties;
+
+    /**
      * Default constructor using "127.0.0.1" as the advertised host.
      */
     public KafkaTestServer() {
@@ -89,6 +95,26 @@ public class KafkaTestServer implements AutoCloseable {
      */
     public KafkaTestServer(final String localHostname) {
         this.localHostname = localHostname;
+        this.overrideBrokerProperties = new Properties();
+    }
+
+    /**
+     * Alternative constructor allowing override of advertised host and brokerProperties.
+     * @param overrideBrokerProperties Define Kafka broker properties.
+     */
+    public KafkaTestServer(final Properties overrideBrokerProperties) {
+        this.localHostname = "127.0.0.1";
+        this.overrideBrokerProperties = overrideBrokerProperties;
+    }
+
+    /**
+     * Alternative constructor allowing override of advertised host and brokerProperties.
+     * @param localHostname What IP or hostname to advertise services on.
+     * @param overrideBrokerProperties Define Kafka broker properties.
+     */
+    public KafkaTestServer(final String localHostname, final Properties overrideBrokerProperties) {
+        this.localHostname = localHostname;
+        this.overrideBrokerProperties = overrideBrokerProperties;
     }
 
     /**
@@ -129,46 +155,55 @@ public class KafkaTestServer implements AutoCloseable {
         zkServer = new TestingServer(zkInstanceSpec, true);
         final String zkConnectionString = getZookeeperServer().getConnectString();
 
-        // Create temp path to store logs
-        final File logDir = Files.createTempDir();
-        logDir.deleteOnExit();
+        // Build properties using a baseline from overrideBrokerProperties.
+        final Properties brokerProperties = new Properties(overrideBrokerProperties);
 
-        // Determine what port to run kafka on
-        kafkaPort = String.valueOf(InstanceSpec.getRandomPort());
+        // Put required zookeeper connection properties.
+        setPropertyIfNotSet(brokerProperties, "zookeeper.connect", zkConnectionString);
 
-        // Build properties
-        Properties kafkaProperties = new Properties();
-        kafkaProperties.setProperty("zookeeper.connect", zkConnectionString);
-        kafkaProperties.setProperty("port", kafkaPort);
-        kafkaProperties.setProperty("log.dir", logDir.getAbsolutePath());
-        kafkaProperties.setProperty("auto.create.topics.enable", "true");
-        kafkaProperties.setProperty("zookeeper.session.timeout.ms", "30000");
-        kafkaProperties.setProperty("broker.id", "1");
-        kafkaProperties.setProperty("auto.offset.reset", "latest");
+        // Conditionally generate a port for kafka to use if not already defined.
+        kafkaPort = (String) setPropertyIfNotSet(brokerProperties, "port", String.valueOf(InstanceSpec.getRandomPort()));
+
+        // If log.dir is not set.
+        if (brokerProperties.getProperty("log.dir") == null) {
+            // Create temp path to store logs
+            final File logDir = Files.createTempDir();
+            logDir.deleteOnExit();
+
+            // Set property.
+            brokerProperties.setProperty("log.dir", logDir.getAbsolutePath());
+        }
 
         // Ensure that we're advertising appropriately
-        kafkaProperties.setProperty("host.name", localHostname);
-        kafkaProperties.setProperty("advertised.host.name", localHostname);
-        kafkaProperties.setProperty("advertised.port", kafkaPort);
-        kafkaProperties.setProperty("advertised.listeners", "PLAINTEXT://" + localHostname + ":" + kafkaPort);
-        kafkaProperties.setProperty("listeners", "PLAINTEXT://" + localHostname + ":" + kafkaPort);
+        setPropertyIfNotSet(brokerProperties, "host.name", localHostname);
+        setPropertyIfNotSet(brokerProperties, "advertised.host.name", localHostname);
+        setPropertyIfNotSet(brokerProperties, "advertised.port", kafkaPort);
+        setPropertyIfNotSet(brokerProperties, "advertised.listeners", "PLAINTEXT://" + localHostname + ":" + kafkaPort);
+        setPropertyIfNotSet(brokerProperties, "listeners", "PLAINTEXT://" + localHostname + ":" + kafkaPort);
+
+        // Set other defaults if not defined.
+        setPropertyIfNotSet(brokerProperties, "auto.create.topics.enable", "true");
+        setPropertyIfNotSet(brokerProperties, "zookeeper.session.timeout.ms", "30000");
+        setPropertyIfNotSet(brokerProperties, "broker.id", "1");
+        setPropertyIfNotSet(brokerProperties, "auto.offset.reset", "latest");
 
         // Lower active threads.
-        kafkaProperties.setProperty("num.io.threads", "2");
-        kafkaProperties.setProperty("num.network.threads", "2");
-        kafkaProperties.setProperty("log.flush.interval.messages", "1");
+        setPropertyIfNotSet(brokerProperties, "num.io.threads", "2");
+        setPropertyIfNotSet(brokerProperties, "num.network.threads", "2");
+        setPropertyIfNotSet(brokerProperties, "log.flush.interval.messages", "1");
 
         // Define replication factor for internal topics to 1
-        kafkaProperties.setProperty("offsets.topic.replication.factor", "1");
-        kafkaProperties.setProperty("offset.storage.replication.factor", "1");
-        kafkaProperties.setProperty("transaction.state.log.replication.factor", "1");
-        kafkaProperties.setProperty("transaction.state.log.min.isr", "1");
-        kafkaProperties.setProperty("transaction.state.log.num.partitions", "4");
-        kafkaProperties.setProperty("config.storage.replication.factor", "1");
-        kafkaProperties.setProperty("status.storage.replication.factor", "1");
-        kafkaProperties.setProperty("default.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "offsets.topic.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "offset.storage.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "transaction.state.log.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "transaction.state.log.min.isr", "1");
+        setPropertyIfNotSet(brokerProperties, "transaction.state.log.num.partitions", "4");
+        setPropertyIfNotSet(brokerProperties, "config.storage.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "status.storage.replication.factor", "1");
+        setPropertyIfNotSet(brokerProperties, "default.replication.factor", "1");
 
-        final KafkaConfig config = new KafkaConfig(kafkaProperties);
+        // Create and start kafka service.
+        final KafkaConfig config = new KafkaConfig(brokerProperties);
         kafka = new KafkaServerStartable(config);
         getKafkaServer().startup();
     }
@@ -191,7 +226,7 @@ public class KafkaTestServer implements AutoCloseable {
         final short replicationFactor = 1;
 
         // Create admin client
-        try (final AdminClient adminClient = KafkaAdminClient.create(buildDefaultClientConfig())) {
+        try (final AdminClient adminClient = getAdminClient()) {
             try {
                 // Define topic
                 final NewTopic newTopic = new NewTopic(topicName, partitions, replicationFactor);
@@ -217,6 +252,14 @@ public class KafkaTestServer implements AutoCloseable {
      */
     public void shutdown() throws Exception {
         close();
+    }
+
+    /**
+     * Creates a Kafka AdminClient connected to our test server.
+     * @return Kafka AdminClient instance.
+     */
+    public AdminClient getAdminClient() {
+        return KafkaAdminClient.create(buildDefaultClientConfig());
     }
 
     /**
@@ -322,6 +365,28 @@ public class KafkaTestServer implements AutoCloseable {
         defaultClientConfig.put("bootstrap.servers", getKafkaConnectString());
         defaultClientConfig.put("client.id", "test-consumer-id");
         return defaultClientConfig;
+    }
+
+    /**
+     * Helper method to conditionally set a property if no value is already set.
+     * @param properties The properties instance to update.
+     * @param key The key to set if not already set.
+     * @param defaultValue The value to set if no value is already set for key.
+     * @return The value set.
+     */
+    private Object setPropertyIfNotSet(final Properties properties, final String key, final String defaultValue) {
+        // Validate inputs
+        Preconditions.checkNotNull(properties);
+        Preconditions.checkNotNull(key);
+
+        // Conditionally set the property if its not already set.
+        properties.setProperty(
+            key,
+            properties.getProperty(key, defaultValue)
+        );
+
+        // Return the value that is being used.
+        return properties.get(key);
     }
 
     /**

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
@@ -80,13 +80,13 @@ public class KafkaTestServer implements AutoCloseable {
     /**
      * Defines overridden broker properties.
      */
-    private final Properties overrideBrokerProperties;
+    private final Properties overrideBrokerProperties = new Properties();
 
     /**
      * Default constructor using "127.0.0.1" as the advertised host.
      */
     public KafkaTestServer() {
-        this("127.0.0.1");
+        this("127.0.0.1", new Properties());
     }
 
     /**
@@ -94,8 +94,7 @@ public class KafkaTestServer implements AutoCloseable {
      * @param localHostname What IP or hostname to advertise services on.
      */
     public KafkaTestServer(final String localHostname) {
-        this.localHostname = localHostname;
-        this.overrideBrokerProperties = new Properties();
+        this(localHostname, new Properties());
     }
 
     /**
@@ -103,8 +102,7 @@ public class KafkaTestServer implements AutoCloseable {
      * @param overrideBrokerProperties Define Kafka broker properties.
      */
     public KafkaTestServer(final Properties overrideBrokerProperties) {
-        this.localHostname = "127.0.0.1";
-        this.overrideBrokerProperties = overrideBrokerProperties;
+        this("127.0.0.1", overrideBrokerProperties);
     }
 
     /**
@@ -114,7 +112,9 @@ public class KafkaTestServer implements AutoCloseable {
      */
     public KafkaTestServer(final String localHostname, final Properties overrideBrokerProperties) {
         this.localHostname = localHostname;
-        this.overrideBrokerProperties = overrideBrokerProperties;
+
+        // Add passed in properties.
+        this.overrideBrokerProperties.putAll(overrideBrokerProperties);
     }
 
     /**

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
@@ -25,8 +25,6 @@
 
 package com.salesforce.kafka.test;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
@@ -361,7 +359,7 @@ public class KafkaTestServer implements AutoCloseable {
      * Internal helper method to build a default configuration.
      */
     private Map<String, Object> buildDefaultClientConfig() {
-        Map<String, Object> defaultClientConfig = Maps.newHashMap();
+        final Map<String, Object> defaultClientConfig = new HashMap<>();
         defaultClientConfig.put("bootstrap.servers", getKafkaConnectString());
         defaultClientConfig.put("client.id", "test-consumer-id");
         return defaultClientConfig;
@@ -376,8 +374,12 @@ public class KafkaTestServer implements AutoCloseable {
      */
     private Object setPropertyIfNotSet(final Properties properties, final String key, final String defaultValue) {
         // Validate inputs
-        Preconditions.checkNotNull(properties);
-        Preconditions.checkNotNull(key);
+        if (properties == null) {
+            throw new NullPointerException("properties argument cannot be null.");
+        }
+        if (key == null) {
+            throw new NullPointerException("key argument cannot be null.");
+        }
 
         // Conditionally set the property if its not already set.
         properties.setProperty(

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java
@@ -26,7 +26,6 @@
 package com.salesforce.kafka.test;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -76,18 +75,18 @@ public class KafkaTestUtils {
         final int partitionId
     ) {
         // This holds the records we produced
-        List<ProducerRecord<byte[], byte[]>> producedRecords = Lists.newArrayList();
+        final List<ProducerRecord<byte[], byte[]>> producedRecords = new ArrayList<>();
 
         // This holds futures returned
-        List<Future<RecordMetadata>> producerFutures = Lists.newArrayList();
+        final List<Future<RecordMetadata>> producerFutures = new ArrayList<>();
 
-        KafkaProducer<byte[], byte[]> producer = kafkaTestServer.getKafkaProducer(
+        final KafkaProducer<byte[], byte[]> producer = kafkaTestServer.getKafkaProducer(
             ByteArraySerializer.class,
             ByteArraySerializer.class
         );
-        for (Map.Entry<byte[], byte[]> entry: keysAndValues.entrySet()) {
+        for (final Map.Entry<byte[], byte[]> entry: keysAndValues.entrySet()) {
             // Construct filter
-            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topicName, partitionId, entry.getKey(), entry.getValue());
+            final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topicName, partitionId, entry.getKey(), entry.getValue());
             producedRecords.add(record);
 
             // Send it.
@@ -100,7 +99,7 @@ public class KafkaTestUtils {
         producer.close();
 
         // Loop thru the futures, and build KafkaRecord objects
-        List<ProducedKafkaRecord<byte[], byte[]>> kafkaRecords = Lists.newArrayList();
+        final List<ProducedKafkaRecord<byte[], byte[]>> kafkaRecords = new ArrayList<>();
         try {
             for (int x = 0; x < keysAndValues.size(); x++) {
                 final RecordMetadata metadata = producerFutures.get(x).get();
@@ -108,9 +107,8 @@ public class KafkaTestUtils {
 
                 kafkaRecords.add(ProducedKafkaRecord.newInstance(metadata, producerRecord));
             }
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+        } catch (final InterruptedException | ExecutionException exception) {
+            throw new RuntimeException(exception);
         }
 
         return kafkaRecords;

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/ZookeeperTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/ZookeeperTestServer.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2017-2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.kafka.test;
+
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Wrapper around TestingServer zookeeper test server instance.  This is here to 'DRY' out the code
+ * between the JUnit4 and JUnit5 implementations.
+ */
+public class ZookeeperTestServer {
+    private static final Logger logger = LoggerFactory.getLogger(ZookeeperTestServer.class);
+
+    /**
+     * Our internal Zookeeper test server instance.
+     */
+    private TestingServer zookeeperTestServer = null;
+
+    /**
+     * Starts the internal Test zookeeper server instance.
+     */
+    public void start() {
+        logger.info("Starting Zookeeper test server");
+        if (zookeeperTestServer != null) {
+            throw new IllegalStateException("Unknown State! Zookeeper test server already exists!");
+        }
+
+        // Setup zookeeper test server
+        final InstanceSpec zkInstanceSpec = new InstanceSpec(null, -1, -1, -1, true, -1, -1, 1000);
+        try {
+            zookeeperTestServer = new TestingServer(zkInstanceSpec, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Stops the internal Test zookeeper server instance.
+     */
+    public void stop() {
+        logger.info("Shutting down zookeeper test server");
+
+        // If we don't have an instance
+        if (zookeeperTestServer != null) {
+            try {
+                zookeeperTestServer.stop();
+                zookeeperTestServer.close();
+
+                // null out reference
+                zookeeperTestServer = null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * @return Underlying shared Zookeeper test server instance.
+     * @throws IllegalStateException if start() has not been called yet.
+     */
+    public TestingServer getZookeeperTestServer() {
+        if (zookeeperTestServer == null) {
+            throw new IllegalStateException("Unable to get test server instance before being created!");
+        }
+        return zookeeperTestServer;
+    }
+
+    /**
+     * @return Connection string to connect to the Zookeeper instance.
+     * @throws IllegalStateException if start() has not been called yet.
+     */
+    public String getZookeeperConnectString() {
+        return getZookeeperTestServer().getConnectString();
+    }
+}

--- a/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
+++ b/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
@@ -116,8 +116,7 @@ class KafkaTestServerTest {
         // Define our override property
         final Properties overrideProperties = new Properties();
         overrideProperties.put("broker.id", expectedBrokerId);
-
-
+        
         // Create our test server instance passing override properties.
         try (final KafkaTestServer kafkaTestServer = new KafkaTestServer(overrideProperties)) {
             // Lets try to be sneaky and change our local property after calling the constructor.

--- a/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
+++ b/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
@@ -25,24 +25,29 @@
 
 package com.salesforce.kafka.test;
 
+import com.google.common.collect.Iterables;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 
 /**
  * Validation tests against KafkaTestServer class.
  */
-public class KafkaTestServerTest {
+class KafkaTestServerTest {
     /**
      * Integration test validates that we can use transactional consumers and producers against the Test kafka instance.
      */
@@ -97,6 +102,43 @@ public class KafkaTestServerTest {
                         consumer.commitSync();
                     }
                 }
+            }
+        }
+    }
+
+    /**
+     * Integration test validates that we can override broker properties.
+     */
+    @Test
+    void testOverrideBrokerProperties() throws Exception {
+        final String expectedBrokerId = "22";
+
+        // Define our override property
+        final Properties overrideProperties = new Properties();
+        overrideProperties.put("broker.id", expectedBrokerId);
+
+
+        // Create our test server instance passing override properties.
+        try (final KafkaTestServer kafkaTestServer = new KafkaTestServer(overrideProperties)) {
+            // Start service
+            kafkaTestServer.start();
+
+            // Create an AdminClient
+            try (final AdminClient adminClient = kafkaTestServer.getAdminClient()) {
+                // Describe details about the cluster
+                final DescribeClusterResult result = adminClient.describeCluster();
+
+                // Get details about the nodes
+                final Collection<Node> nodes = result.nodes().get();
+
+                // Sanity test
+                Assertions.assertEquals(1, nodes.size(), "Should only have a single node");
+
+                // Get details about our test broker/node
+                final Node node = Iterables.get(nodes, 0);
+
+                // Validate
+                Assertions.assertEquals(expectedBrokerId, node.idString(), "Has expected overridden broker Id");
             }
         }
     }

--- a/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
+++ b/kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java
@@ -120,6 +120,10 @@ class KafkaTestServerTest {
 
         // Create our test server instance passing override properties.
         try (final KafkaTestServer kafkaTestServer = new KafkaTestServer(overrideProperties)) {
+            // Lets try to be sneaky and change our local property after calling the constructor.
+            // This shouldn't have any effect on the properties already passed into the constructor.
+            overrideProperties.put("broker.id", "1000");
+
             // Start service
             kafkaTestServer.start();
 

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -154,7 +154,7 @@ SharedKafkaTestResource has two accessors that you can make use of in your tests
 Often times you'll end up rebuilding the same patterns around producing and consuming data from this internal
 kafka server.  We've tried to collect some of these within [KafkaTestUtils](../kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java)!
 
-For usage and examples, check out it's test at [KafkaTestUtilsTest](../kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
+For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
 
 #### Zookeeper Test Server
 
@@ -162,8 +162,7 @@ For usage and examples, check out it's test at [KafkaTestUtilsTest](../kafka-jun
  both of these together within the same Test class.
 
 If you need to run tests against an **only** embedded Zookeeper server and not all of Kafka, we have you covered as well.  Add the following
- to your JUnit test file 
-and it will handle automatically start and stopping the embedded Zookeeper instance for you.
+ to your JUnit test class and it will handle automatically start and stopping the embedded Zookeeper instance for you.
 
 ```java
     /**

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -127,7 +127,7 @@ SharedKafkaTestResource exposes the ability to override properties set on the te
     /**
      * This is an example of how to override configuration values for the test kafka broker instance.
      * 
-     * Here we define the broker.id to be set to 100, and disable topic auto-creation.
+     * Here we define the broker.id to be set to 1000, and disable topic auto-creation.
      */
     @ClassRule
     public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
@@ -135,7 +135,7 @@ SharedKafkaTestResource exposes the ability to override properties set on the te
         .withBrokerProperty("auto.create.topics.enable", "false");
 ```
 
-SharedKafkaTestResource has two accessors that you can make use of in your tests to interact with the service.
+[SharedKafkaTestResource](src/main/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResource.java) instance has two accessors that you can make use of in your tests to interact with the service.
 
 ```java
     /**
@@ -154,7 +154,7 @@ SharedKafkaTestResource has two accessors that you can make use of in your tests
 Often times you'll end up rebuilding the same patterns around producing and consuming data from this internal
 kafka server.  We've tried to collect some of these within [KafkaTestUtils](../kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java)!
 
-For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
+For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/junit4/KafkaTestUtilsTest.java).
 
 #### Zookeeper Test Server
 
@@ -175,7 +175,7 @@ If you need to run tests against an **only** embedded Zookeeper server and not a
     public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
 ```
 
-SharedZookeeperTestResource has the following accessors that you can make use of in your tests to interact with the Zookeeper instance.
+[SharedZookeeperTestResource](src/main/java/com/salesforce/kafka/test/junit4/SharedZookeeperTestResource.java) has the following accessors that you can make use of in your tests to interact with the Zookeeper instance.
 
 ```java
     /**

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -105,7 +105,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 
 #### KafkaTestServer
 
-A great example of how to use this can be found within our tests!  Check out [KafkaTestServerTest.java](src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java)
+A great example of how to use this can be found within our tests!  Check out [SharedKafkaTestResourceTest.java](src/test/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResourceTest.java).
 
 Add the following to your JUnit test file and it will handle automatically starting and stopping the embedded Kafka 
 instance for you.
@@ -119,6 +119,20 @@ instance for you.
      */
     @ClassRule
     public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
+```
+
+SharedKafkaTestResource exposes the ability to override properties set on the test kafka broker instance.
+
+```java
+    /**
+     * This is an example of how to override configuration values for the test kafka broker instance.
+     * 
+     * Here we define the broker.id to be set to 100, and disable topic auto-creation.
+     */
+    @ClassRule
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .withBrokerProperty("broker.id", "1000")
+        .withBrokerProperty("auto.create.topics.enable", "false");
 ```
 
 SharedKafkaTestResource has two accessors that you can make use of in your tests to interact with the service.
@@ -138,9 +152,9 @@ SharedKafkaTestResource has two accessors that you can make use of in your tests
 #### KafkaTestUtils
 
 Often times you'll end up rebuilding the same patterns around producing and consuming data from this internal
-kafka server.  We've tried to collect some of these within [KafkaTestUtils](src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java)!
+kafka server.  We've tried to collect some of these within [KafkaTestUtils](../kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java)!
 
-For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
+For usage and examples, check out it's test at [KafkaTestUtilsTest](../kafka-junit-core/src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
 
 #### Zookeeper Test Server
 

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.1</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
 
     <!-- defined properties -->
     <properties>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>2.2.1</version>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit4/src/main/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResource.java
+++ b/kafka-junit4/src/main/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResource.java
@@ -32,6 +32,8 @@ import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Properties;
+
 /**
  * Creates and stands up an internal test kafka server to be shared across test cases within the same test class.
  *
@@ -57,6 +59,55 @@ public class SharedKafkaTestResource extends ExternalResource {
     private KafkaTestUtils kafkaTestUtils = null;
 
     /**
+     * Additional broker properties.
+     */
+    private final Properties brokerProperties = new Properties();
+
+    /**
+     * Default constructor.
+     */
+    public SharedKafkaTestResource() {
+        this(new Properties());
+    }
+
+    /**
+     * Constructor allowing passing additional broker properties.
+     * @param brokerProperties properties for Kafka broker.
+     */
+    public SharedKafkaTestResource(final Properties brokerProperties) {
+        this.brokerProperties.putAll(brokerProperties);
+    }
+
+    /**
+     * Helper to allow overriding Kafka broker properties.  Can only be called prior to the service
+     * being started.
+     * @param name Kafka broker configuration property name.
+     * @param value Value to set for the configuration property.
+     * @return SharedKafkaTestResource instance for method chaining.
+     * @throws IllegalArgumentException if name argument is null.
+     * @throws IllegalStateException if method called after service has started.
+     */
+    public SharedKafkaTestResource withBrokerProperty(final String name, final String value) {
+        // Validate input.
+        if (name == null) {
+            throw new IllegalArgumentException("Cannot pass null name argument");
+        }
+
+        // Validate state.
+        if (kafkaTestServer != null) {
+            throw new IllegalStateException("Cannot add properties after service has started");
+        }
+
+        // Add or set property.
+        if (value == null) {
+            brokerProperties.remove(name);
+        } else {
+            brokerProperties.put(name, value);
+        }
+        return this;
+    }
+
+    /**
      * Here we stand up an internal test kafka and zookeeper service.
      * Once for all tests that use this shared resource.
      */
@@ -66,7 +117,7 @@ public class SharedKafkaTestResource extends ExternalResource {
             throw new IllegalStateException("Unknown State!  Kafka Test Server already exists!");
         }
         // Setup kafka test server
-        kafkaTestServer = new KafkaTestServer();
+        kafkaTestServer = new KafkaTestServer(brokerProperties);
         kafkaTestServer.start();
     }
 

--- a/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/KafkaTestUtilsTest.java
+++ b/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/KafkaTestUtilsTest.java
@@ -86,7 +86,7 @@ public class KafkaTestUtilsTest {
         final int partitionId = 2;
 
         // Create our utility class
-        final KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
+        final KafkaTestUtils kafkaTestUtils = sharedKafkaTestResource.getKafkaTestUtils();
 
         // Produce some random records
         final List<ProducedKafkaRecord<byte[], byte[]>> producedRecordsList =

--- a/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResourceTest.java
+++ b/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/SharedKafkaTestResourceTest.java
@@ -114,7 +114,8 @@ public class SharedKafkaTestResourceTest {
         final ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, partitionId, expectedKey, expectedValue);
 
         // Create a new producer
-        final KafkaProducer<String, String> producer = getKafkaTestServer().getKafkaProducer(StringSerializer.class, StringSerializer.class);
+        final KafkaProducer<String, String> producer =
+            getKafkaTestServer().getKafkaProducer(StringSerializer.class, StringSerializer.class);
 
         // Produce it & wait for it to complete.
         final Future<RecordMetadata> future = producer.send(producerRecord);

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -105,33 +105,37 @@ Include this library in your project's POM with test scope.  **You'll also need 
 
 #### KafkaTestServer
 
-A great example of how to use this can be found within our tests!  Check out [KafkaTestServerTest.java](src/test/java/com/salesforce/kafka/test/KafkaTestServerTest.java)
+A great example of how to use this can be found within our tests!  Check out [SharedKafkaTestResourceTest.java](src/test/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResourceTest.java).
 
-Annotate your JUnit test class with `@ExtendWith(KafkaResourceExtension.class)` and add the appropriate constructor.  The JUnit5 extension will handle automatically starting and stopping the embedded Kafka 
+Add the following to your JUnit test file and it will handle automatically starting and stopping the embedded Kafka 
 instance for you.  
 
 ```java
-@ExtendWith(KafkaResourceExtension.class)
-public class MyTestClass {
     /**
      * We have a single embedded kafka server that gets started when this test class is initialized.
      *
-     * It's automatically started before any methods are run via the @ExtendWith annotation.
-     * It's automatically stopped after all of the tests are completed via the @ExtendWith annotation.
-     * This instance is passed to this class's constructor via the @ExtendWith annotation.
+     * It's automatically started before any methods are run via the @ClassRule annotation.
+     * It's automatically stopped after all of the tests are completed via the @ClassRule annotation.
      */
-    private final SharedKafkaTestResource sharedKafkaTestResource;
-
-    /**
-     * Constructor where KafkaResourceExtension provides the sharedKafkaTestResource object.
-     * @param sharedKafkaTestResource Provided by KafkaResourceExtension.
-     */
-    public MyTestClass(final SharedKafkaTestResource sharedKafkaTestResource) {
-        this.sharedKafkaTestResource = sharedKafkaTestResource;
-    }
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
 ```
 
-[SharedKafkaTestResource](kafka-junit5/src/main/java/test/junit/SharedKafkaTestResource.java) instance has two accessors that you can make use of in your tests to interact with the service.
+SharedKafkaTestResource exposes the ability to override properties set on the test kafka broker instance.
+
+```java
+    /**
+     * This is an example of how to override configuration values for the test kafka broker instance.
+     * 
+     * Here we define the broker.id to be set to 1000, and disable topic auto-creation.
+     */
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .withBrokerProperty("broker.id", "1000")
+        .withBrokerProperty("auto.create.topics.enable", "false");
+```
+
+[SharedKafkaTestResource](src/main/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResource.java) instance has two accessors that you can make use of in your tests to interact with the service.
 
 ```java
     /**
@@ -148,40 +152,30 @@ public class MyTestClass {
 #### KafkaTestUtils
 
 Often times you'll end up rebuilding the same patterns around producing and consuming data from this internal
-kafka server.  We've tried to collect some of these within [KafkaTestUtils](kafka-junit5/src/main/java/test/KafkaTestUtils.java)!
+kafka server.  We've tried to collect some of these within [KafkaTestUtils](../kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java)!
 
-For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/KafkaTestUtilsTest.java).
+For usage and examples, check out it's test at [KafkaTestUtilsTest](src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java).
 
 #### Zookeeper Test Server
 
-**Note** Since Kafka depends on Zookeeper, you get this for *free* if you use the [KafkaResourceExtension](kafka-junit5/src/main/java/test/junit/KafkaResourceExtension.java), you do not, and should not, use
-both of these together within the same Test class.
+**Note** Since Kafka depends on Zookeeper, you get this for *free* if you use the SharedKafkaTestResource, you do not, and should not, use
+ both of these together within the same Test class.
 
-If you need to run tests against an **only** embedded Zookeeper server and not all of Kafka, we have you covered as well.  Add the following annotation to your JUnit test class
- and it will handle automatically start and stopping the embedded Zookeeper instance for you.
+If you need to run tests against an **only** embedded Zookeeper server and not all of Kafka, we have you covered as well.  Add the following 
+to your JUnit test class and it will handle automatically start and stopping the embedded Zookeeper instance for you.
 
 ```java
-@ExtendWith(ZookeeperResourceExtension.class)
-public class MyTestClass {
     /**
      * We have a single embedded zookeeper server that gets started when this test class is initialized.
      *
-     * It's automatically started before any methods are run via the @ExtendWith annotation.
-     * It's automatically stopped after all of the tests are completed via the @ExtendWith annotation.
-     * This instance is passed to this class's constructor via the @ExtendWith annotation.
+     * It's automatically started before any methods are run via the @ClassRule annotation.
+     * It's automatically stopped after all of the tests are completed via the @ClassRule annotation.
      */
-    private final SharedZookeeperTestResource sharedZookeeperTestResource;
-
-    /**
-     * Constructor where KafkaResourceExtension provides the sharedKafkaTestResource object.
-     * @param sharedZookeeperTestResource Provided by ZookeeperResourceExtension.
-     */
-    public MyTestClass(final SharedZookeeperTestResource sharedZookeeperTestResource) {
-        this.sharedZookeeperTestResource = sharedZookeeperTestResource;
-    }
+    @RegisterExtension
+    public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
 ```
 
-[SharedZookeeperTestResource](kafka-junit5/src/main/java/test/junit/SharedZookeeperTestResource.java) has the following accessors that you can make use of in your tests to interact with the Zookeeper instance.
+[SharedZookeeperTestResource](src/main/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResource.java) has the following accessors that you can make use of in your tests to interact with the Zookeeper instance.
 
 ```java
     /**

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -3,7 +3,7 @@
 This library wraps Kafka Test Server and allows you to easily create and run tests against
 a "real" kafka server running within your tests, no more needing to stand up an external kafka cluster!
 
-Kafka-JUnit5 is built on-top of **JUnit 5** as an Extension using the **@ExtendWith** annotation.
+Kafka-JUnit5 is built on-top of **JUnit 5** as an Extension using the **@RegisterExtension** annotation.
 
 Kafka-JUnit5 works with Kafka versions **0.11.0.x**, **1.0.x**, and **1.1.x** and must be explicitly declared in your project's POM.
 
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>2.2.1</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
 
     <!-- defined properties -->
     <properties>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>2.2.1</version>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/KafkaResourceExtension.java
+++ b/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/KafkaResourceExtension.java
@@ -35,6 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * @deprecated This class is superseded by SharedKafkaTestResource.
+ *
  * JUnit 5 extension to provide an internal test kafka server to be shared across test cases within the same test class.
  *
  * Annotate your test class with:
@@ -50,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * Within your test case methods:
  *   this.sharedKafkaTestResource.getKafkaTestServer()...
  */
+@Deprecated
 public class KafkaResourceExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
     private static final Logger logger = LoggerFactory.getLogger(KafkaResourceExtension.class);
 
@@ -64,12 +67,8 @@ public class KafkaResourceExtension implements BeforeAllCallback, AfterAllCallba
      */
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        logger.info("Starting kafka test server");
-
         // Start kafka test server
-        kafkaTestResource
-            .getKafkaTestServer()
-            .start();
+        kafkaTestResource.beforeAll(context);
     }
 
     /**
@@ -77,16 +76,7 @@ public class KafkaResourceExtension implements BeforeAllCallback, AfterAllCallba
      */
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        logger.info("Shutting down kafka test server");
-
-        // Close out kafka test server if needed
-        try {
-            kafkaTestResource
-                .getKafkaTestServer()
-                .shutdown();
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
+        kafkaTestResource.afterAll(context);
         kafkaTestResource = null;
     }
 

--- a/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/KafkaResourceExtension.java
+++ b/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/KafkaResourceExtension.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @deprecated This class is superseded by SharedKafkaTestResource.
+ * This class is superseded by SharedKafkaTestResource.  Please reference it instead of this class.
  *
  * JUnit 5 extension to provide an internal test kafka server to be shared across test cases within the same test class.
  *
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory;
  *
  * Within your test case methods:
  *   this.sharedKafkaTestResource.getKafkaTestServer()...
+ *
+ * @deprecated This class is superseded by SharedKafkaTestResource.
  */
 @Deprecated
 public class KafkaResourceExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {

--- a/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResource.java
+++ b/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResource.java
@@ -25,86 +25,53 @@
 
 package com.salesforce.kafka.test.junit5;
 
-import org.apache.curator.test.InstanceSpec;
+import com.salesforce.kafka.test.ZookeeperTestServer;
 import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * Shared Zookeeper Test Resource instance.  Contains references to internal Zookeeper server instances.
  */
 public class SharedZookeeperTestResource implements BeforeAllCallback, AfterAllCallback {
-    private static final Logger logger = LoggerFactory.getLogger(SharedZookeeperTestResource.class);
-
     /**
      * Our internal Zookeeper test server instance.
      */
-    private TestingServer zookeeperTestServer = null;
+    private final ZookeeperTestServer zookeeperTestServer = new ZookeeperTestServer();
 
     /**
      * @return Shared Zookeeper test server instance.
-     * @throws IllegalStateException if beforeAll() has not been called yet.
+     * @throws IllegalStateException if before() has not been called yet.
      */
-    public TestingServer getZookeeperTestServer() {
-        if (zookeeperTestServer == null) {
-            throw new IllegalStateException("Unable to get test server instance before being created!");
-        }
-        return zookeeperTestServer;
+    public TestingServer getZookeeperTestServer() throws IllegalStateException {
+        return zookeeperTestServer.getZookeeperTestServer();
     }
 
     /**
      * @return Connection string to connect to the Zookeeper instance.
+     * @throws IllegalStateException if before() has not been called yet.
      */
-    public String getZookeeperConnectString() {
-        return getZookeeperTestServer().getConnectString();
-    }
-
-    /**
-     * Here we shut down the internal test zookeeper service.
-     */
-    @Override
-    public void afterAll(ExtensionContext context) throws Exception {
-        logger.info("Shutting down zookeeper test server");
-
-        // If we don't have an instance
-        if (zookeeperTestServer == null) {
-            // Nothing to close.
-            return;
-        }
-
-        try {
-            zookeeperTestServer.stop();
-            zookeeperTestServer.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        // null out reference
-        zookeeperTestServer = null;
+    public String getZookeeperConnectString() throws IllegalStateException {
+        return zookeeperTestServer.getZookeeperConnectString();
     }
 
     /**
      * Here we stand up an internal test zookeeper service.
-     * Once for all tests that use this shared resource.
+     * once for all tests that use this shared resource.
+     * @throws RuntimeException on startup errors.
      */
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
-        logger.info("Starting Zookeeper test server");
-        if (zookeeperTestServer != null) {
-            throw new IllegalStateException("Unknown State! Zookeeper test server already exists!");
-        }
+    public void beforeAll(ExtensionContext context) throws RuntimeException {
+        zookeeperTestServer.start();
+    }
 
-        // Setup zookeeper test server
-        final InstanceSpec zkInstanceSpec = new InstanceSpec(null, -1, -1, -1, true, -1, -1, 1000);
-        try {
-            zookeeperTestServer = new TestingServer(zkInstanceSpec, true);
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
-        }
+    /**
+     * Here we shut down the internal test zookeeper service.
+     * @throws RuntimeException on shutdown errors.
+     */
+    @Override
+    public void afterAll(ExtensionContext context) {
+        zookeeperTestServer.stop();
     }
 }

--- a/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/ZookeeperResourceExtension.java
+++ b/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/ZookeeperResourceExtension.java
@@ -25,19 +25,16 @@
 
 package com.salesforce.kafka.test.junit5;
 
-import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
+ * @deprecated This class is superseded by SharedZookeeperTestResource.
+ *
  * JUnit 5 extension to provide an internal test zookeeper server to be shared across test cases within the same test class.
  *
  * Annotate your test class with:
@@ -54,34 +51,16 @@ import java.io.IOException;
  *   this.sharedZookeeperTestResource.getZookeeperTestServer()...
  *   this.sharedZookeeperTestResource.getZookeeperConnectString()...
  */
+@Deprecated
 public class ZookeeperResourceExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
-    private static final Logger logger = LoggerFactory.getLogger(ZookeeperResourceExtension.class);
-
-    private SharedZookeeperTestResource zookeeperTestResource = null;
+    private final SharedZookeeperTestResource zookeeperTestResource = new SharedZookeeperTestResource();
 
     /**
      * Here we shut down the internal test zookeeper service.
      */
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        logger.info("Shutting down zookeeper test server");
-
-        // If we don't have an instance
-        if (zookeeperTestResource == null) {
-            // Nothing to close.
-            return;
-        }
-
-        try {
-            final TestingServer testingServer = zookeeperTestResource.getZookeeperTestServer();
-            testingServer.stop();
-            testingServer.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        // null out reference
-        zookeeperTestResource = null;
+        zookeeperTestResource.afterAll(context);
     }
 
     /**
@@ -90,12 +69,8 @@ public class ZookeeperResourceExtension implements BeforeAllCallback, AfterAllCa
      */
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        logger.info("Starting Zookeeper test server");
-        if (zookeeperTestResource != null) {
-            throw new IllegalStateException("Unknown State! Zookeeper test server already exists!");
-        }
         // Setup zookeeper test server
-        zookeeperTestResource = new SharedZookeeperTestResource();
+        zookeeperTestResource.beforeAll(context);
     }
 
     @Override

--- a/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/ZookeeperResourceExtension.java
+++ b/kafka-junit5/src/main/java/com/salesforce/kafka/test/junit5/ZookeeperResourceExtension.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
- * @deprecated This class is superseded by SharedZookeeperTestResource.
+ * This class is superseded by SharedZookeeperTestResource.  Please reference it instead of this class.
  *
  * JUnit 5 extension to provide an internal test zookeeper server to be shared across test cases within the same test class.
  *
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * Within your test case methods:
  *   this.sharedZookeeperTestResource.getZookeeperTestServer()...
  *   this.sharedZookeeperTestResource.getZookeeperConnectString()...
+ *
+ * @deprecated This class is superseded by SharedZookeeperTestResource.
  */
 @Deprecated
 public class ZookeeperResourceExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaResourceExtensionTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaResourceExtensionTest.java
@@ -51,9 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @deprecated Please use SharedKafkaTestResourceTest as a reference for using this library.
- *
  * This serves as an example of how to use this library using @ExtendWith annotation.
+ *
+ * @deprecated Please use SharedKafkaTestResourceTest as a reference for using this library.
  */
 @Deprecated
 @ExtendWith(KafkaResourceExtension.class)

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
@@ -86,7 +86,7 @@ class KafkaTestUtilsTest {
         final int partitionId = 2;
 
         // Create our utility class
-        final KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
+        final KafkaTestUtils kafkaTestUtils = sharedKafkaTestResource.getKafkaTestUtils();
 
         // Produce some random records
         final List<ProducedKafkaRecord<byte[], byte[]>> producedRecordsList =

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
@@ -32,7 +32,7 @@ import com.salesforce.kafka.test.ProducedKafkaRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Serves both as a test for the Utilities, but also as a good example of how to use them.
  */
-@ExtendWith(KafkaResourceExtension.class)
-public class KafkaTestUtilsTest {
+class KafkaTestUtilsTest {
     private static final Logger logger = LoggerFactory.getLogger(KafkaTestUtilsTest.class);
 
     /**
@@ -55,21 +54,14 @@ public class KafkaTestUtilsTest {
      * It's automatically started before any methods are run via the @ClassRule annotation.
      * It's automatically stopped after all of the tests are completed via the @ClassRule annotation.
      */
-    private final SharedKafkaTestResource sharedKafkaTestResource;
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
 
     /**
      * Before every test, we generate a random topic name and create it within the embedded kafka server.
      * Each test can then be segmented run any tests against its own topic.
      */
     private String topicName;
-
-    /**
-     * Constructor where KafkaResourceExtension provides the sharedKafkaTestResource object.
-     * @param sharedKafkaTestResource Provided by KafkaResourceExtension.
-     */
-    public KafkaTestUtilsTest(SharedKafkaTestResource sharedKafkaTestResource) {
-        this.sharedKafkaTestResource = sharedKafkaTestResource;
-    }
 
     /**
      * This happens once before every test method.

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResourceTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResourceTest.java
@@ -26,7 +26,6 @@
 package com.salesforce.kafka.test.junit5;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.salesforce.kafka.test.KafkaTestServer;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -47,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -127,31 +127,30 @@ class SharedKafkaTestResourceTest {
         // Close producer!
         producer.close();
 
-        KafkaConsumer<String, String> kafkaConsumer =
-            getKafkaTestServer().getKafkaConsumer(StringDeserializer.class, StringDeserializer.class);
+        // Create consumer
+        try (final KafkaConsumer<String, String> kafkaConsumer =
+            getKafkaTestServer().getKafkaConsumer(StringDeserializer.class, StringDeserializer.class)) {
 
-        final List<TopicPartition> topicPartitionList = Lists.newArrayList();
-        for (final PartitionInfo partitionInfo: kafkaConsumer.partitionsFor(topicName)) {
-            topicPartitionList.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
-        }
-        kafkaConsumer.assign(topicPartitionList);
-        kafkaConsumer.seekToBeginning(topicPartitionList);
-
-        // Pull records from kafka, keep polling until we get nothing back
-        ConsumerRecords<String, String> records;
-        do {
-            records = kafkaConsumer.poll(2000L);
-            logger.info("Found {} records in kafka", records.count());
-            for (ConsumerRecord<String, String> record: records) {
-                // Validate
-                assertEquals(expectedKey, record.key(), "Key matches expected");
-                assertEquals(expectedValue, record.value(), "value matches expected");
+            final List<TopicPartition> topicPartitionList = new ArrayList<>();
+            for (final PartitionInfo partitionInfo : kafkaConsumer.partitionsFor(topicName)) {
+                topicPartitionList.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
             }
-        }
-        while (!records.isEmpty());
+            kafkaConsumer.assign(topicPartitionList);
+            kafkaConsumer.seekToBeginning(topicPartitionList);
 
-        // close consumer
-        kafkaConsumer.close();
+            // Pull records from kafka, keep polling until we get nothing back
+            ConsumerRecords<String, String> records;
+            do {
+                records = kafkaConsumer.poll(2000L);
+                logger.info("Found {} records in kafka", records.count());
+                for (ConsumerRecord<String, String> record : records) {
+                    // Validate
+                    assertEquals(expectedKey, record.key(), "Key matches expected");
+                    assertEquals(expectedValue, record.value(), "value matches expected");
+                }
+            }
+            while (!records.isEmpty());
+        }
     }
 
     /**

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResourceTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedKafkaTestResourceTest.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2017-2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.salesforce.kafka.test.junit5;
 
 import com.google.common.collect.Iterables;

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResourceTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResourceTest.java
@@ -1,0 +1,48 @@
+package com.salesforce.kafka.test.junit5;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test of SharedZookeeperTestResource.
+ *
+ * This also serves as an example of how to use this library!
+ */
+class SharedZookeeperTestResourceTest {
+    /**
+     * We have a single embedded zookeeper server that gets started when this test class is initialized.
+     *
+     * It's automatically started before any methods are run via the @ExtendWith annotation.
+     * It's automatically stopped after all of the tests are completed via the @ExtendWith annotation.
+     * This instance is passed to this class's constructor via the @ExtendWith annotation.
+     */
+    @RegisterExtension
+    public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
+
+    /**
+     * Validates that we receive a sane looking ZK connection string.
+     */
+    @Test
+    void testGetZookeeperConnectString() {
+        final String actualConnectStr = sharedZookeeperTestResource.getZookeeperConnectString();
+
+        // Validate
+        assertNotNull(actualConnectStr, "Should have non-null connect string");
+        assertTrue(actualConnectStr.startsWith("127.0.0.1:"), "Should start with 127.0.0.1");
+    }
+
+    /**
+     * Validates that we receive a sane looking ZK connection string.
+     */
+    @Test
+    void testZookeeperServer() {
+        final TestingServer zkTestServer = sharedZookeeperTestResource.getZookeeperTestServer();
+
+        // Validate
+        assertNotNull(zkTestServer, "Should have non-null instance");
+    }
+}

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResourceTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/SharedZookeeperTestResourceTest.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2017-2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.salesforce.kafka.test.junit5;
 
 import org.apache.curator.test.TestingServer;

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/ZookeeperResourseExtensionTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/ZookeeperResourseExtensionTest.java
@@ -33,11 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * This serves as an example of how to use this library using @ExtendWith annotation.
+ *
  * @deprecated Please use SharedZookeeperTestResourceTest as a reference for using this library.
- *
- * Test of ZookeeperResourceExtension.
- *
- * This also serves as an example of how to use this library!
  */
 @Deprecated
 @ExtendWith(ZookeeperResourceExtension.class)

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/ZookeeperResourseExtensionTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/ZookeeperResourseExtensionTest.java
@@ -33,12 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test of Zookeeper Test instance.
+ * @deprecated Please use SharedZookeeperTestResourceTest as a reference for using this library.
+ *
+ * Test of ZookeeperResourceExtension.
  *
  * This also serves as an example of how to use this library!
  */
+@Deprecated
 @ExtendWith(ZookeeperResourceExtension.class)
-public class ZookeeperTestServerTest {
+public class ZookeeperResourseExtensionTest {
     /**
      * We have a single embedded zookeeper server that gets started when this test class is initialized.
      *
@@ -52,7 +55,7 @@ public class ZookeeperTestServerTest {
      * Constructor where KafkaResourceExtension provides the sharedKafkaTestResource object.
      * @param sharedZookeeperTestResource Provided by ZookeeperResourceExtension.
      */
-    public ZookeeperTestServerTest(final SharedZookeeperTestResource sharedZookeeperTestResource) {
+    public ZookeeperResourseExtensionTest(final SharedZookeeperTestResource sharedZookeeperTestResource) {
         this.sharedZookeeperTestResource = sharedZookeeperTestResource;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <!-- Submodules -->
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
                         <exclude>**.yml</exclude>
                         <exclude>**.yaml</exclude>
                         <exclude>**.xml</exclude>
+                        <exclude>**.versionsBackup</exclude>
                         <exclude>script/**</exclude>
                     </excludes>
                 </configuration>
@@ -212,6 +213,7 @@
                             <violationSeverity>warning</violationSeverity>
                             <failsOnError>true</failsOnError>
                             <enableRSS>false</enableRSS>
+                            <linkXRef>false</linkXRef>
 
                             <!-- By default we enable checkstyle validation -->
                             <skip>${skipCheckStyle}</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
 
     <!-- Submodules -->
     <modules>


### PR DESCRIPTION
for #12 

- [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
- Added helper method getAdminClient() on KafkaTestServer to get a configured AdminClient instance.
- Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.
- Deprecated KafkaTestServer constructor: `public KafkaTestServer(final String localHostname)`
  
  This constructor was replaced with the constructor `KafkaTestServer(final Properties overrideBrokerProperties)` where overrideBrokerProperties should contain the property `host.name` set to the hostname or IP address Kafka should use. 
