### PR TITLE
[issue-16] Don't cache KafkaTestUtils instance.  If the SharedKafkaTes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.0.1 (06/29/2018)
 - [Issue-16](https://github.com/salesforce/kafka-junit/issues/16) Bugfix for re-using the same SharedKafkaTestResource instance multiple times, as might happen if you run a test multiple times.
+- Update checkstyle plugin version to 3.0.0
 
 ## 3.0.0 (05/29/2018)
 - Added ability to start 1 or more Kafka brokers configured within a functional cluster.  This allows you to now to test functionality that depends on more than one broker within your cluster, as well as scenarios around how your code handles broker availability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.0.0 (5/29/2018)
+## 3.0.1 (06/29/2018)
+- [Issue-16](https://github.com/salesforce/kafka-junit/issues/16) Bugfix for re-using the same SharedKafkaTestResource instance multiple times, as might happen if you run a test multiple times.
+
+## 3.0.0 (05/29/2018)
 - Added ability to start 1 or more Kafka brokers configured within a functional cluster.  This allows you to now to test functionality that depends on more than one broker within your cluster, as well as scenarios around how your code handles broker availability.
 - Expanded the methods available in the [KafkaTestUtils](kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java) class.
 
@@ -10,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Several accessors were removed from SharedKafkaTestResource and should now be accessed
   via the KafkaTestUtils class.  In most cases simply changing from `sharedKafkaTestResource.getKafkaServer()....` to `sharedKafkaTestResource.getKafkaTestUtils()...` will be sufficient to migrate your code. 
 
-## 2.3.0 (5/17/2018)
+## 2.3.0 (05/17/2018)
 - [Issue-12](https://github.com/salesforce/kafka-junit/issues/12) Added ability to pass broker properties to be used by test kafka service instance.
 - Added helper method getAdminClient() on KafkaTestServer to get a configured AdminClient instance.
 - Deprecated Kafka-JUnit5 @ExtendWith annotation implementations.  This has been replaced in favor of @RegisterExtension annotation.  Review [README.md](kafka-junit5/README.md) for more information on updated usage instructions.
@@ -18,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   
   This constructor was replaced with the constructor `KafkaTestServer(final Properties overrideBrokerProperties)` where overrideBrokerProperties should contain the property `host.name` set to the hostname or IP address Kafka should use. 
 
-## 2.2.0 (4/24/2018)
+## 2.2.0 (04/24/2018)
 - [Issue-5](https://github.com/salesforce/kafka-junit/issues/5) Updated to support Kafka versions 1.0.x and 1.1.x.  Thanks [kasuri](https://github.com/kasuri)!
 - [Issue-4](https://github.com/salesforce/kafka-junit/issues/4) Fix server configuration to allow for transactional producers & consumers. 
 
@@ -51,10 +54,10 @@ See below for an example...for more details refer to README.
 </dependency>
 ```
 
-## 2.1.0 (4/24/2018)
+## 2.1.0 (04/24/2018)
  - Bungled release. Please use version 2.2.0.
 
-## 2.0.0 (4/10/2018)
+## 2.0.0 (04/10/2018)
 - Created new modules to support both JUnit4 and JUnit 5.
 
 ## 1.0.0 (09/11/2017)

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 
     <!-- Module Dependencies -->
     <dependencies>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/AbstractKafkaTestResource.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/AbstractKafkaTestResource.java
@@ -38,11 +38,6 @@ public abstract class AbstractKafkaTestResource<T extends AbstractKafkaTestResou
     private KafkaCluster kafkaCluster = null;
 
     /**
-     * Cached instance of KafkaTestUtils.
-     */
-    private KafkaTestUtils kafkaTestUtils = null;
-
-    /**
      * Additional broker properties.
      */
     private final Properties brokerProperties = new Properties();
@@ -117,12 +112,7 @@ public abstract class AbstractKafkaTestResource<T extends AbstractKafkaTestResou
     public KafkaTestUtils getKafkaTestUtils() {
         // Validate internal state.
         validateState(true, "Cannot access KafkaTestUtils before Kafka service has been started.");
-
-        // Create instance if it doesn't exist yet.
-        if (kafkaTestUtils == null) {
-            kafkaTestUtils = new KafkaTestUtils(kafkaCluster);
-        }
-        return kafkaTestUtils;
+        return new KafkaTestUtils(kafkaCluster);
     }
 
     /**

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 
     <!-- Submodules -->
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <configuration>
                     <configLocation>${checkstyle.ruleset}</configLocation>
                 </configuration>


### PR DESCRIPTION
…tResource instance is re-used it could cache old references.

fixes #16 