### PR TITLE
Remove Guava usages in favor of built-in JDK methods to avoid potenti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.1 (03/22/2019)
+- Replace internal uses of Guava with JDK-comparable methods so that if a transitive dependency on Curator resolves to a more recent version that shades Guava this library will not break.
+
 ## 3.1.0 (12/13/2018)
 - Officially support Kafka 2.0.x
 - KafkaTestUtils.produceRecords() and its variants now set producer configuration "acks" to "all"

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <!-- defined properties -->
     <properties>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestUtils.java
@@ -25,7 +25,6 @@
 
 package com.salesforce.kafka.test;
 
-import com.google.common.base.Charsets;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
@@ -51,6 +50,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -169,7 +169,7 @@ public class KafkaTestUtils {
             final String value = "value" + timeStamp;
 
             // Add to map
-            keysAndValues.put(key.getBytes(Charsets.UTF_8), value.getBytes(Charsets.UTF_8));
+            keysAndValues.put(key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8));
         }
 
         return produceRecords(keysAndValues, topicName, partitionId);

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
@@ -39,7 +39,6 @@ class Utils {
      */
     static File createTempDirectory() {
         // Create temp path to store logs
-//        Files.createTempDirectory()
         final File logDir;
         try {
             logDir = Files.createTempDirectory("kafka-unit").toFile();

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
@@ -25,9 +25,9 @@
 
 package com.salesforce.kafka.test;
 
-import com.google.common.io.Files;
-
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Collection of Utilities.
@@ -39,7 +39,13 @@ class Utils {
      */
     static File createTempDirectory() {
         // Create temp path to store logs
-        final File logDir = Files.createTempDir();
+//        Files.createTempDirectory()
+        final File logDir;
+        try {
+            logDir = Files.createTempDirectory("kafka-unit").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         // Ensure its removed on termination.
         logDir.deleteOnExit();

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/KafkaTestUtilsTest.java
+++ b/kafka-junit4/src/test/java/com/salesforce/kafka/test/junit4/KafkaTestUtilsTest.java
@@ -25,7 +25,6 @@
 
 package com.salesforce.kafka.test.junit4;
 
-import com.google.common.base.Charsets;
 import com.salesforce.kafka.test.KafkaTestUtils;
 import com.salesforce.kafka.test.ProducedKafkaRecord;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -42,6 +41,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Iterator;
@@ -196,10 +196,10 @@ public class KafkaTestUtilsTest {
         // You can get details about what got produced into Kafka, including the partition and offset for each message.
         for (final ProducedKafkaRecord<byte[], byte[]> producedKafkaRecord: producedRecordsList) {
             // This is the key of the message that was produced.
-            final String key = new String(producedKafkaRecord.getKey(), Charsets.UTF_8);
+            final String key = new String(producedKafkaRecord.getKey(), StandardCharsets.UTF_8);
 
             // This is the value of the message that was produced.
-            final String value = new String(producedKafkaRecord.getValue(), Charsets.UTF_8);
+            final String value = new String(producedKafkaRecord.getValue(), StandardCharsets.UTF_8);
 
             // Other details about topic, partition, and offset it was written onto.
             final String topic = producedKafkaRecord.getTopic();
@@ -228,8 +228,8 @@ public class KafkaTestUtilsTest {
             final ConsumerRecord<String, String> consumerRecord = consumerRecordIterator.next();
             final ProducedKafkaRecord<byte[], byte[]> producedKafkaRecord = producedKafkaRecordIterator.next();
 
-            final String expectedKey = new String(producedKafkaRecord.getKey(), Charsets.UTF_8);
-            final String expectedValue = new String(producedKafkaRecord.getValue(), Charsets.UTF_8);
+            final String expectedKey = new String(producedKafkaRecord.getKey(), StandardCharsets.UTF_8);
+            final String expectedValue = new String(producedKafkaRecord.getValue(), StandardCharsets.UTF_8);
             final String actualKey = consumerRecord.key();
             final String actualValue = consumerRecord.value();
 

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
+++ b/kafka-junit5/src/test/java/com/salesforce/kafka/test/junit5/KafkaTestUtilsTest.java
@@ -25,7 +25,6 @@
 
 package com.salesforce.kafka.test.junit5;
 
-import com.google.common.base.Charsets;
 import com.salesforce.kafka.test.KafkaTestUtils;
 import com.salesforce.kafka.test.ProducedKafkaRecord;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Iterator;
@@ -196,10 +196,10 @@ class KafkaTestUtilsTest {
         // You can get details about what got produced into Kafka, including the partition and offset for each message.
         for (final ProducedKafkaRecord<byte[], byte[]> producedKafkaRecord: producedRecordsList) {
             // This is the key of the message that was produced.
-            final String key = new String(producedKafkaRecord.getKey(), Charsets.UTF_8);
+            final String key = new String(producedKafkaRecord.getKey(), StandardCharsets.UTF_8);
 
             // This is the value of the message that was produced.
-            final String value = new String(producedKafkaRecord.getValue(), Charsets.UTF_8);
+            final String value = new String(producedKafkaRecord.getValue(), StandardCharsets.UTF_8);
 
             // Other details about topic, partition, and offset it was written onto.
             final String topic = producedKafkaRecord.getTopic();
@@ -228,8 +228,8 @@ class KafkaTestUtilsTest {
             final ConsumerRecord<String, String> consumerRecord = consumerRecordIterator.next();
             final ProducedKafkaRecord<byte[], byte[]> producedKafkaRecord = producedKafkaRecordIterator.next();
 
-            final String expectedKey = new String(producedKafkaRecord.getKey(), Charsets.UTF_8);
-            final String expectedValue = new String(producedKafkaRecord.getValue(), Charsets.UTF_8);
+            final String expectedKey = new String(producedKafkaRecord.getKey(), StandardCharsets.UTF_8);
+            final String expectedValue = new String(producedKafkaRecord.getValue(), StandardCharsets.UTF_8);
             final String actualKey = consumerRecord.key();
             final String actualValue = consumerRecord.value();
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <!-- Submodules -->
     <modules>


### PR DESCRIPTION
…al conflicts with newer versions of Curator

Curator appears to have shaded Guava a long time ago, and any transitive update could and probably will break consumers.
This replaces existing usages with JDK-comparable methods.