### PR TITLE
[ISSUE-36] Temp directories are not being cleaned up properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.1.2 (11/08/2019)
-- [ISSUE-36]() Temporary directories should now be cleaned up properly on JVM shutdown.
+- [ISSUE-36](https://github.com/salesforce/kafka-junit/issues/36) Temporary directories should now be cleaned up properly on JVM shutdown.
 
 ## 3.1.1 (03/22/2019)
 - Replace internal uses of Guava with JDK-comparable methods so that if a transitive dependency on Curator resolves to a more recent version that shades Guava this library will not break.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.2 (11/08/2019)
+- [ISSUE-36]() Temporary directories should now be cleaned up properly on JVM shutdown.
+
 ## 3.1.1 (03/22/2019)
 - Replace internal uses of Guava with JDK-comparable methods so that if a transitive dependency on Curator resolves to a more recent version that shades Guava this library will not break.
 

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <!-- defined properties -->
     <properties>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
@@ -73,17 +73,17 @@ class Utils {
                         }
 
                         @Override
-                        public FileVisitResult postVisitDirectory(final Path dir, final IOException e) throws IOException {
-                            if (e == null) {
+                        public FileVisitResult postVisitDirectory(final Path dir, final IOException exception) throws IOException {
+                            if (exception == null) {
                                 Files.delete(dir);
                                 return FileVisitResult.CONTINUE;
                             }
                             // directory iteration failed
-                            throw e;
+                            throw exception;
                         }
                     });
-                } catch (final IOException e) {
-                    throw new RuntimeException("Failed to delete " + path, e);
+                } catch (final IOException exception) {
+                    throw new RuntimeException("Failed to delete " + path, exception);
                 }
             }
         ));

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/Utils.java
@@ -27,7 +27,11 @@ package com.salesforce.kafka.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * Collection of Utilities.
@@ -39,16 +43,49 @@ class Utils {
      */
     static File createTempDirectory() {
         // Create temp path to store logs
-        final File logDir;
+        final Path logDir;
         try {
-            logDir = Files.createTempDirectory("kafka-unit").toFile();
-        } catch (IOException e) {
+            logDir = Files.createTempDirectory("kafka-unit");
+        } catch (final IOException e) {
             throw new RuntimeException(e);
         }
 
-        // Ensure its removed on termination.
-        logDir.deleteOnExit();
+        // Ensure its removed on termination by recursively removing all files under the temp directory.
+        Utils.recursiveDeleteOnShutdownHook(logDir);
 
-        return logDir;
+        // Return as a File
+        return logDir.toFile();
+    }
+
+    /**
+     * Registers a shutdown hook to recursively cleanup/delete a directory and all of it's contents.
+     * @param path the Path to remove.
+     */
+    private static void recursiveDeleteOnShutdownHook(final Path path) {
+        Runtime.getRuntime().addShutdownHook(new Thread(
+            () -> {
+                try {
+                    Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                            Files.delete(file);
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult postVisitDirectory(final Path dir, final IOException e) throws IOException {
+                            if (e == null) {
+                                Files.delete(dir);
+                                return FileVisitResult.CONTINUE;
+                            }
+                            // directory iteration failed
+                            throw e;
+                        }
+                    });
+                } catch (final IOException e) {
+                    throw new RuntimeException("Failed to delete " + path, e);
+                }
+            }
+        ));
     }
 }

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -110,7 +110,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <!-- defined properties -->
     <properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -31,7 +31,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -57,7 +57,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -83,7 +83,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 
@@ -109,7 +109,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <!-- defined properties -->
     <properties>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
 
     <!-- Submodules -->
     <modules>


### PR DESCRIPTION
Fix for #36 .

`Files.deleteOnExit()` will only remove a directory if it is empty.  Update the code to register a JVM shutdown hook to recursively delete files within the temp directory.

In the future we may want to explore having this cleanup code execute when the kafka service is stopped, instead of when the JVM shutdown.