### PR TITLE
add support for explicitly configured broker ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.0 (11/13/2019)
+- [ISSUE-38](https://github.com/salesforce/kafka-junit/issues/38) Optionally allow for explicitly defining which ports kakfa brokers listen on.
+
 ## 3.1.2 (11/08/2019)
 - [ISSUE-36](https://github.com/salesforce/kafka-junit/issues/36) Temporary directories should now be cleaned up properly on JVM shutdown.
 

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
 
     <!-- defined properties -->
     <properties>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/KafkaTestServer.java
@@ -29,7 +29,6 @@ import com.salesforce.kafka.test.listeners.BrokerListener;
 import com.salesforce.kafka.test.listeners.PlainListener;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
-import org.apache.curator.test.InstanceSpec;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -262,8 +261,8 @@ public class KafkaTestServer implements KafkaCluster, KafkaProvider, AutoCloseab
 
             // Loop over registered listeners and add each
             for (final BrokerListener listener : registeredListeners) {
-                // Generate port to listen on.
-                final int port = InstanceSpec.getRandomPort();
+                // Get port to listen on.
+                final int port = listener.getNextPort();
                 final String listenerDefinition = listener.getProtocol() + "://" + getConfiguredHostname() + ":" + port;
                 listenerProperties.add(
                     new ListenerProperties(listener.getProtocol(), listenerDefinition, listener.getClientProperties())

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/AbstractListener.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/AbstractListener.java
@@ -25,25 +25,53 @@
 
 package com.salesforce.kafka.test.listeners;
 
-import java.util.Properties;
+import org.apache.curator.test.InstanceSpec;
 
 /**
- * Default implementation.  Defines a PLAINTEXT listener.
+ * Shared Listener class.
+ *
+ * @param <Self> reference to parent class.
  */
-public class PlainListener extends AbstractListener<PlainListener> {
+public abstract class AbstractListener<Self> implements BrokerListener {
+    /**
+     * Defines which port(s) to listen on.
+     */
+    private int[] ports = {};
+    private int portIndex = 0;
 
-    @Override
-    public String getProtocol() {
-        return "PLAINTEXT";
+    /**
+     * Optionally allow for explicitly defining which ports this listener will bind to.
+     * Pass a unique port per broker running.
+     *
+     * If not explicitly called, random ports will be assigned to each listener and broker.
+     *
+     * @param ports the ports to bind to.
+     * @return self for method chaining.
+     */
+    public Self onPorts(final int ... ports) {
+        this.ports = ports;
+        return (Self) this;
     }
 
-    @Override
-    public Properties getBrokerProperties() {
-        return new Properties();
+    /**
+     * The ports configured.
+     * @return Configured ports.
+     */
+    public int[] getPorts() {
+        return ports;
     }
 
-    @Override
-    public Properties getClientProperties() {
-        return new Properties();
+    /**
+     * Internal method to get the next assigned port.  If called more times than configured ports,
+     * this method will generate a random port to be used.
+     *
+     * @return next configured port to use.
+     */
+    public int getNextPort() {
+        if (ports == null || ports.length == 0 || portIndex >= ports.length) {
+            // Return random Port
+            return InstanceSpec.getRandomPort();
+        }
+        return ports[portIndex++];
     }
 }

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/BrokerListener.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/BrokerListener.java
@@ -54,4 +54,18 @@ public interface BrokerListener {
      * @return Properties to be registered on connecting client.
      */
     Properties getClientProperties();
+
+    /**
+     * The ports configured.
+     * @return Configured ports.
+     */
+    int[] getPorts();
+
+    /**
+     * Internal method to get the next assigned port.  If called more times than configured ports,
+     * this method will generate a random port to be used.
+     *
+     * @return next configured port to use.
+     */
+    int getNextPort();
 }

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SaslPlainListener.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SaslPlainListener.java
@@ -39,7 +39,7 @@ import java.util.Properties;
  * In order to make use of this Listener, you **must** start the JVM with the following:
  *  -Djava.security.auth.login.config=/path/to/your/jaas.conf
  */
-public class SaslPlainListener implements BrokerListener {
+public class SaslPlainListener extends AbstractListener<SaslPlainListener> {
     private static final Logger logger = LoggerFactory.getLogger(SaslPlainListener.class);
 
     private String username = "";

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SaslSslListener.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SaslSslListener.java
@@ -39,7 +39,7 @@ import java.util.Properties;
  * In order to make use of this Listener, you **must** start the JVM with the following:
  *  -Djava.security.auth.login.config=/path/to/your/jaas.conf
  */
-public class SaslSslListener implements BrokerListener {
+public class SaslSslListener extends AbstractListener<SaslSslListener> {
     private static final Logger logger = LoggerFactory.getLogger(SaslSslListener.class);
 
     // SASL Settings.

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SslListener.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SslListener.java
@@ -30,7 +30,7 @@ import java.util.Properties;
 /**
  * Define and register an SSL listener on a Kafka broker.
  */
-public class SslListener implements BrokerListener {
+public class SslListener extends AbstractListener<SslListener> {
 
     private String trustStoreFile = "";
     private String trustStorePassword = "";

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +58,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +84,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -110,7 +110,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -253,6 +253,32 @@ a cluster with 4 Kafka brokers. The Kafka brokers will have id's that start and 
             .withUsername("YourUsername")
             .withPassword("YourPassword")
         );
+```
+
+##### Configuring explicit ports for broker(s)
+If you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+
+```java
+    /**
+     * This is an example of how to start a broker on an explicitly defined port of 1234.
+     * The onPorts() can be called on any of the above listener types.
+     */
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .registerListener(new PlainListener().onPorts(1234));
+
+    /**
+     * If you are running a multi-broker cluster, you will need to pass a unique port for each 
+     * broker in the cluster.
+     * 
+     * This example will have 2 brokers where:
+     *   The first broker is listening on port 1234.
+     *   The second broker is listening on port 4321.
+     */
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .withBrokers(2)
+        .registerListener(new PlainListener().onPorts(1234, 4321));
 ```
 
 ##### Helpful methods on SharedKafkaTestResource

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -256,7 +256,9 @@ a cluster with 4 Kafka brokers. The Kafka brokers will have id's that start and 
 ```
 
 ##### Configuring explicit ports for broker(s)
-If you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+Optionally if you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+
+Not calling the `onPorts()` method will have the broker(s) listen on randomly assigned ports.
 
 ```java
     /**

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
 
     <!-- defined properties -->
     <properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -20,7 +20,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -31,7 +31,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -57,7 +57,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -83,7 +83,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -109,7 +109,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
     <scope>test</scope>
 </dependency>
 
@@ -252,6 +252,32 @@ a cluster with 4 Kafka brokers. The Kafka brokers will have id's that start and 
             .withUsername("YourUsername")
             .withPassword("YourPassword")
         );
+```
+
+##### Configuring explicit ports for broker(s)
+If you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+
+```java
+    /**
+     * This is an example of how to start a broker on an explicitly defined port of 1234.
+     * The onPorts() can be called on any of the above listener types.
+     */
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .registerListener(new PlainListener().onPorts(1234));
+
+    /**
+     * If you are running a multi-broker cluster, you will need to pass a unique port for each 
+     * broker in the cluster.
+     * 
+     * This example will have 2 brokers where:
+     *   The first broker is listening on port 1234.
+     *   The second broker is listening on port 4321.
+     */
+    @RegisterExtension
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
+        .withBrokers(2)
+        .registerListener(new PlainListener().onPorts(1234, 4321));
 ```
 
 ##### Helpful methods on SharedKafkaTestResource

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -255,7 +255,10 @@ a cluster with 4 Kafka brokers. The Kafka brokers will have id's that start and 
 ```
 
 ##### Configuring explicit ports for broker(s)
-If you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+Optionally if you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.
+
+Not calling the `onPorts()` method will have the broker(s) listen on randomly assigned ports.
+
 
 ```java
     /**

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
 
     <!-- defined properties -->
     <properties>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.0</version>
 
     <!-- Submodules -->
     <modules>

--- a/script/checkstyle-ruleset.xml
+++ b/script/checkstyle-ruleset.xml
@@ -119,12 +119,12 @@
                      value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ClassTypeParameterName">
-            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)|([A-Z][a-zA-Z0-9]*$)"/>
             <message key="name.invalidPattern"
                      value="Class type name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="MethodTypeParameterName">
-            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)|([A-Z][a-zA-Z0-9]*$)"/>
             <message key="name.invalidPattern"
                      value="Method type name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
Fix for #38 
##### Configuring explicit ports for broker(s)
Optionally if you require specific ports for the Kafka brokers to listen on, you can use the `BrokerListener.onPorts(...)` method when registering a listener.

Not calling the `onPorts()` method will have the broker(s) listen on randomly assigned ports.


```java
    /**
     * This is an example of how to start a broker on an explicitly defined port of 1234.
     * The onPorts() can be called on any of the above listener types.
     */
    @RegisterExtension
    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
        .registerListener(new PlainListener().onPorts(1234));

    /**
     * If you are running a multi-broker cluster, you will need to pass a unique port for each 
     * broker in the cluster.
     * 
     * This example will have 2 brokers where:
     *   The first broker is listening on port 1234.
     *   The second broker is listening on port 4321.
     */
    @RegisterExtension
    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource()
        .withBrokers(2)
        .registerListener(new PlainListener().onPorts(1234, 4321));
```