### PR TITLE
update internal dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,19 @@ env:
 -
   KAFKA_VERSION=2.0.1
   EXCLUDE_KAFKA_TESTS=0_11_0_x
+-
+  KAFKA_VERSION=2.1.1
+  EXCLUDE_KAFKA_TESTS=0_11_0_x
+-
+  KAFKA_VERSION=2.2.2
+  EXCLUDE_KAFKA_TESTS=0_11_0_x
+-
+  KAFKA_VERSION=2.3.1
+  EXCLUDE_KAFKA_TESTS=0_11_0_x
+-
+  KAFKA_VERSION=2.4.0
+  EXCLUDE_KAFKA_TESTS=0_11_0_x
+
 script:
   ## Generate dummy SSL Certificates used in tests
   - script/generateCertificatesForTests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   This caused issues with Kafka version 2.1.x on startup and shutdown causing tests to hang.
 
 ### Internal dependency updates
-- JUnit4 from 2.14 to 2.13
+- JUnit4 from 2.12 to 2.13
 - JUnit5 from 5.3.2 to 5.6.0
 
 ## 3.2.0 (11/13/2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.1 (02/03/2020)
+[PR-42](https://github.com/salesforce/kafka-junit/pull/42)
+
+### Features
+- Officially added support for Kafka versions 2.1.x, 2.2.x, 2.3.x, 2.4.x.
+
+### Bugfix
+- Fixes bug in `ZookeeperTestServer.start()` where calling start on an already running instance caused the instance to be restarted instead of being a no-operation.
+  This caused issues with Kafka version 2.1.x on startup and shutdown causing tests to hang.
+
+### Internal dependency updates
+- JUnit4 from 2.14 to 2.13
+- JUnit5 from 5.3.2 to 5.6.0
+
 ## 3.2.0 (11/13/2019)
 - [ISSUE-38](https://github.com/salesforce/kafka-junit/issues/38) Optionally allow for explicitly defining which ports kakfa brokers listen on.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ one or more "real" kafka brokers. No longer do you need to setup and coordinate 
 
 ## Features
 - Support for JUnit 4 and JUnit 5.
-- Support for Kafka versions 2.0.x, 1.1.x, 1.0.x, and 0.11.0.x.
+- Support for all Kafka versions between 0.11.0.x to 2.4.x
 - Support for running either single broker cluster, or multi-broker clusters.
 - Support for PLAINTEXT, SASL_PLAINTEXT, SASL_SSL, and SSL listeners.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ one or more "real" kafka brokers. No longer do you need to setup and coordinate 
 
 ## Features
 - Support for JUnit 4 and JUnit 5.
-- Support for all Kafka versions between 0.11.0.x to 2.4.x
+- Support for all Kafka versions from 0.11.0.x through 2.4.x
 - Support for running either single broker cluster, or multi-broker clusters.
 - Support for PLAINTEXT, SASL_PLAINTEXT, SASL_SSL, and SSL listeners.
 

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.18.3</version>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.12</version>
+            <version>3.4.14</version>
             <scope>test</scope>
         </dependency>
 

--- a/kafka-junit-core/pom.xml
+++ b/kafka-junit-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit-core</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 
     <!-- defined properties -->
     <properties>

--- a/kafka-junit-core/src/main/java/com/salesforce/kafka/test/ZookeeperTestServer.java
+++ b/kafka-junit-core/src/main/java/com/salesforce/kafka/test/ZookeeperTestServer.java
@@ -44,9 +44,20 @@ public class ZookeeperTestServer implements AutoCloseable {
     private TestingServer zkServer = null;
 
     /**
+     * Internal state flag.
+     */
+    private boolean isStarted = false;
+
+    /**
      * Starts the internal Test zookeeper server instance.
      */
     public void start() {
+        // If we're already started
+        if (isStarted) {
+            // Do nothing.
+            return;
+        }
+
         try {
             if (zkServer == null) {
                 // Define configuration
@@ -72,6 +83,9 @@ public class ZookeeperTestServer implements AutoCloseable {
         } catch (final Exception exception) {
             throw new RuntimeException(exception.getMessage(), exception);
         }
+
+        // Set internal state flag
+        isStarted = true;
     }
 
     /**
@@ -88,6 +102,9 @@ public class ZookeeperTestServer implements AutoCloseable {
         // Otherwise call restart.
         try {
             zkServer.restart();
+
+            // Ensure flag is set correctly.
+            isStarted = true;
         } catch (final Exception exception) {
             throw new RuntimeException(exception.getMessage(), exception);
         }
@@ -109,6 +126,8 @@ public class ZookeeperTestServer implements AutoCloseable {
                 throw new RuntimeException(exception.getMessage(), exception);
             }
         }
+        // Set internal state flag.
+        isStarted = false;
     }
 
     /**

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -5,7 +5,7 @@ one or more "real" kafka brokers running within your tests. No longer do you nee
 
 Kafka-JUnit4 is built on-top of **JUnit 4** as a SharedResource using the **@ClassRule** annotation.
 
-Kafka-JUnit4 works with all Kafka versions from **0.11.0.x**, to **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
+Kafka-JUnit4 works with all Kafka versions from **0.11.0.x** through **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
 
 For usage with JUnit5 or more general project information please review top level [README](../README.md).
 

--- a/kafka-junit4/README.md
+++ b/kafka-junit4/README.md
@@ -5,7 +5,7 @@ one or more "real" kafka brokers running within your tests. No longer do you nee
 
 Kafka-JUnit4 is built on-top of **JUnit 4** as a SharedResource using the **@ClassRule** annotation.
 
-Kafka-JUnit4 works with Kafka versions **0.11.0.x**, **1.0.x**, **1.1.x**, and **2.0.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
+Kafka-JUnit4 works with all Kafka versions from **0.11.0.x**, to **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
 
 For usage with JUnit5 or more general project information please review top level [README](../README.md).
 
@@ -20,7 +20,107 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.4.x
+```xml
+<!-- Declare kafka-junit4 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit4</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.4.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.4.0</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.4.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.3.x
+```xml
+<!-- Declare kafka-junit4 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit4</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.3.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.3.1</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.3.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.2.x
+```xml
+<!-- Declare kafka-junit4 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit4</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.2.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.2.2</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.2.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.1.x
+```xml
+<!-- Declare kafka-junit4 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit4</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.1.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.1.1</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.1.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -32,7 +132,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -58,7 +158,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -84,7 +184,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -110,7 +210,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit4/pom.xml
+++ b/kafka-junit4/pom.xml
@@ -32,13 +32,13 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <!-- Module Definition & Version -->
     <artifactId>kafka-junit4</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -5,7 +5,7 @@ one or more "real" kafka brokers running within your tests. No longer do you nee
 
 Kafka-JUnit5 is built on-top of **JUnit 5** as an Extension using the **@RegisterExtension** annotation.
 
-Kafka-JUnit5 works with all Kafka versions from **0.11.0.x**, to **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
+Kafka-JUnit5 works with all Kafka versions from **0.11.0.x** through **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
 
 For usage with JUnit4 or more general project information please review top level [README](../README.md). 
 

--- a/kafka-junit5/README.md
+++ b/kafka-junit5/README.md
@@ -5,7 +5,7 @@ one or more "real" kafka brokers running within your tests. No longer do you nee
 
 Kafka-JUnit5 is built on-top of **JUnit 5** as an Extension using the **@RegisterExtension** annotation.
 
-Kafka-JUnit5 works with Kafka versions **0.11.0.x**, **1.0.x**, **1.1.x**, and **2.0.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
+Kafka-JUnit5 works with all Kafka versions from **0.11.0.x**, to **2.4.x**. The library requires your project to explicitly declare/include Kafka in your project's POM dependency list.
 
 For usage with JUnit4 or more general project information please review top level [README](../README.md). 
 
@@ -20,7 +20,107 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.4.x
+```xml
+<!-- Declare kafka-junit5 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit5</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.4.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.4.0</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.4.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.3.x
+```xml
+<!-- Declare kafka-junit5 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit5</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.3.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.3.1</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.3.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.2.x
+```xml
+<!-- Declare kafka-junit5 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit5</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.2.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.2.2</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.2.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+#### POM for Kafka 2.1.x
+```xml
+<!-- Declare kafka-junit5 dependency -->
+<dependency>
+    <groupId>com.salesforce.kafka.test</groupId>
+    <artifactId>kafka-junit5</artifactId>
+    <version>3.2.1</version>
+    <scope>test</scope>
+</dependency>
+
+<!-- Include Kafka 2.1.x -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>2.1.1</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>2.1.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -31,7 +131,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -57,7 +157,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -83,7 +183,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 
@@ -109,7 +209,7 @@ Include this library in your project's POM with test scope.  **You'll also need 
 <dependency>
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <scope>test</scope>
 </dependency>
 

--- a/kafka-junit5/pom.xml
+++ b/kafka-junit5/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <artifactId>kafka-junit</artifactId>
         <groupId>com.salesforce.kafka.test</groupId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kafka-junit5</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 
     <!-- defined properties -->
     <properties>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.salesforce.kafka.test</groupId>
             <artifactId>kafka-junit-core</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.1</version>
         </dependency>
 
         <!-- JUnit is Required -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>com.salesforce.kafka.test</groupId>
     <artifactId>kafka-junit</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 
     <!-- Submodules -->
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,12 @@
         <curatorTestVersion>2.12.0</curatorTestVersion>
 
         <!-- For logging in tests -->
-        <slf4jVersion>1.7.25</slf4jVersion>
+        <slf4jVersion>1.7.30</slf4jVersion>
 
         <!-- JUnit versions -->
-        <junit4.version>4.12</junit4.version>
-        <junit5.version>5.3.2</junit5.version>
-        <junit5PlatformProvider.version>1.2.0</junit5PlatformProvider.version>
+        <junit4.version>4.13</junit4.version>
+        <junit5.version>5.6.0</junit5.version>
+        <junit5PlatformProvider.version>1.3.2</junit5PlatformProvider.version>
 
         <!-- test toggling -->
         <skipTests>false</skipTests>
@@ -104,9 +104,9 @@
         <checkstyle.ruleset>script/checkstyle-ruleset.xml</checkstyle.ruleset>
 
         <!-- plugin versions -->
-        <checkstyle.version>3.0.0</checkstyle.version>
-        <javadoc.version>3.0.1</javadoc.version>
-        <surefire.version>2.22.0</surefire.version>
+        <checkstyle.version>3.1.0</checkstyle.version>
+        <javadoc.version>3.1.1</javadoc.version>
+        <surefire.version>2.22.2</surefire.version>
 
         <!-- excluded tests based on specific kafka versions -->
         <!-- default to excluding 0.11.0.x tests -->
@@ -275,7 +275,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.18</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/script/checkstyle-ruleset.xml
+++ b/script/checkstyle-ruleset.xml
@@ -32,6 +32,11 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="LineLength">
+        <property name="max" value="140"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
         <module name="OuterTypeFilename"/>
@@ -44,10 +49,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="140"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
@@ -177,12 +178,13 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
-            <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
+            <property name="allowMissingParamTags" value="false"/>
+            <property name="allowMissingReturnTag" value="false"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="validateThrows" value="false"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="minLineCount" value="2"/>
         </module>
         <module name="JavadocStyle">
             <property name="scope" value="public"/>


### PR DESCRIPTION
### Features
- Officially added support for Kafka versions 2.1.x, 2.2.x, 2.3.x, 2.4.x.

### Bugfix
- Fixes bug in `ZookeeperTestServer.start()` where calling start on an already running instance caused the instance to be restarted instead of being a no-operation.
  This caused issues with Kafka version 2.1.x on startup and shutdown causing tests to hang.

### Internal dependency updates
- JUnit4 from 2.12 to 2.13
- JUnit5 from 5.3.2 to 5.6.0
